### PR TITLE
Corrige une TemplateSyntaxError

### DIFF
--- a/base/templates/base/base.html
+++ b/base/templates/base/base.html
@@ -1,4 +1,4 @@
-{% load staticfiles %}
+{% load static %}
 
 <!DOCTYPE html>
 <html lang="fr">

--- a/base/templates/base/index.html
+++ b/base/templates/base/index.html
@@ -1,6 +1,6 @@
 {% extends "base/base.html" %}
 
-{% load staticfiles %}
+{% load static %}
 
 {% block content %}
 <div class="index-part">


### PR DESCRIPTION
Sur l'installation par défaut

{% load static %} a été supprimé en Django 3.0