### PR TITLE
Fixe les versions des dépendances

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
-django
-django-crispy-forms
-openpyxl
+django>=2.2,<3.0  # LTS version
+django-crispy-forms>=1.9.2,<1.10
+# We can bump to openpyxl 3.x once we drop Debian Strech (Py3.5) support
+openpyxl>=2.6.4,<3.0


### PR DESCRIPTION
Pour l'instant, je conserve le support de Debian Stretch, car je me demande si
ça n'est pas stretch sur le serveur des GASE nantais…

Fix #19