### PR TITLE
YunoHost : évite un double git clone

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -45,7 +45,7 @@ ynh_webpath_available $domain $path
 ynh_install_app_dependencies $pkg_dependencies
 
 sudo mkdir -p $final_path
-git clone https://github.com/Jojo144/compteur_du_gase $final_path
+cp -r .. $final_path
 
 python3 -m venv $final_path/venv
 venv_python=$final_path/venv/bin/python3

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -26,7 +26,7 @@ final_path=/opt/$app
 venv_python=$final_path/venv/bin/python3
 venv_pip=$final_path/venv/bin/pip
 
-cd $final_path && git pull
+rsync -va ../ $final_path/
 sudo -u $app $venv_pip install -r $final_path/requirements.txt
 sudo -u $app $venv_python $final_path/manage.py migrate --noinput
 

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -24,8 +24,10 @@ ynh_script_progression --message="Upgrading..." --time --weight=1
 
 final_path=/opt/$app
 venv_python=$final_path/venv/bin/python3
+venv_pip=$final_path/venv/bin/pip
 
 cd $final_path && git pull
+sudo -u $app $venv_pip install -r $final_path/requirements.txt
 sudo -u $app $venv_python $final_path/manage.py migrate --noinput
 
 


### PR DESCRIPTION
On a déjà le code à ce stade de l'install, inutile de cloner à nouveau.

En outre, cloner ici empechait d'installer une version locale du package
yunohost (ou issue d'un dépôt/branche différente).