### PR TITLE
Installe les paquets binaires plutôt que source

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-pkg_dependencies="python3-pip python3-virtualenv python3-venv sqlite3"
+pkg_dependencies="python3-pip python3-virtualenv python3-venv python3-wheel sqlite3"


### PR DESCRIPTION
Le paquet python-wheel permet d'utiliser des paquets binaires plutôt que source lorsqu'ils sont dispo (pour les dépendances pip). Ça permet de gagner du temps et des risques de merdouillage de compilation à l'install.

Le log d'install mentionait qu'il y avait un fallback sur les paquets source car wheel n'était pas installé :    2020-11-29 

    18:43:36,528: DEBUG - Using legacy setup.py install for django-easy-select2, since package 'wheel' is not installed.