### PR TITLE
Corrige un crash « KeyError » à l'installation

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -62,7 +62,7 @@
             },
 	    {
                 "name": "email",
-                "type": "email",
+                "type": "string",
                 "ask": {
                     "en": "Choose email were send error notifications",
                     "fr": "Choisissez l'email vers lequel envoyer les notifications d'erreur"


### PR DESCRIPTION
Parce-que « email » n'est pas un type de question supporté¹  dans le format du manifest.json


Ça faisait un truc genre 

```
root@ynh:/ynh-dev# yunohost app install https://github.com/Jojo144/compteur_du_gase
DANGER! This app is not part of Yunohost's app catalog. Installing third-party apps may compromise the integrity and security of your system. You should probably NOT install it unless you know what you are doing. NO SUPPORT will be provided if this app doesn't work or breaks your system… If you are willing to take that risk anyway, type 'Yes, I understand': Yes, I understand
Choose the domain where this app should be installed [ynh.dev] (default: ynh.dev): ynh.dev
Choose the path where this app should be installed (default: /): 
Choose the administrator of your app (does not need to be an existing YunoHost user) (default: admin): admin
Choose a password for this administrator: 
Traceback (most recent call last):
  File "/usr/bin/yunohost", line 72, in <module>
    parser=parser
  File "/usr/lib/moulinette/yunohost/__init__.py", line 29, in cli
    top_parser=parser
  File "/usr/lib/python2.7/dist-packages/moulinette/__init__.py", line 120, in cli
    args, output_as=output_as, timeout=timeout
  File "/usr/lib/python2.7/dist-packages/moulinette/interfaces/cli.py", line 469, in run
    ret = self.actionsmap.process(args, timeout=timeout)
  File "/usr/lib/python2.7/dist-packages/moulinette/actionsmap.py", line 587, in process
    return func(**arguments)
  File "/usr/lib/moulinette/yunohost/log.py", line 358, in func_wrapper
    result = func(*args, **kwargs)
  File "/usr/lib/moulinette/yunohost/app.py", line 750, in app_install
    args_odict = _parse_args_from_manifest(manifest, 'install', args=args_dict)
  File "/usr/lib/moulinette/yunohost/app.py", line 2381, in _parse_args_from_manifest
    return _parse_args_in_yunohost_format(args, action_args)
  File "/usr/lib/moulinette/yunohost/app.py", line 2624, in _parse_args_in_yunohost_format
    parser = ARGUMENTS_TYPE_PARSERS[question.get("type", "string")]()
KeyError: u'email'

```


¹ https://yunohost.org/#/packaging_apps_manifest_fr