### PR TITLE
Propose pour le dév de viser une BDD différente

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,7 +58,7 @@ coverage.xml
 # Django stuff:
 *.log
 local_settings.py
-db.sqlite3
+/*.sqlite3
 
 # Flask stuff:
 instance/

--- a/HACKING.md
+++ b/HACKING.md
@@ -1,0 +1,7 @@
+# Coder sur le compteur du GASE
+
+## Environnement de développement
+
+Il est recommandé d'utiliser des paramètres personalisés pour le dév :
+
+    cp compteur/settings_local.py.dev.example compteur/settings_local.py

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ Différentes options sont également disponibles dans l'interface graphique dans
 
 Toutes les remarques et contributions sont les bienvenues. N'hésitez pas à entrer en contact avec moi si vous souhaitez l'installer dans votre épicerie.
 
+Pour le développement, des détails techniques sont disponibles dans le fichier [HACKING.md](./HACKING.md)
+
 Contact : jojo144@girole.fr
 
 ## Installation

--- a/compteur/settings_local.py.dev.example
+++ b/compteur/settings_local.py.dev.example
@@ -1,0 +1,15 @@
+import os
+
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+# Utilise une base de données nommée différement de la BDD par défaut Évite les
+# problèmes bizarres comme la base de données de dév qui est copiée et utilisée
+# sur le serveur yunohost lorsqu'on teste l'app yunohost depuis le dossier de
+# dév.
+#
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': os.path.join(BASE_DIR, 'db-dev.sqlite3'),
+    }
+}

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -26,7 +26,8 @@ final_path=/opt/$app
 venv_python=$final_path/venv/bin/python3
 venv_pip=$final_path/venv/bin/pip
 
-rsync -va ../ $final_path/
+# Les exclude sont là pour permettre les tests de paquet ynh en local
+rsync -va ../ $final_path/ --filter=':- ../.gitignore' --exclude=/conf/gunicorn_config.py
 sudo -u $app $venv_pip install -r $final_path/requirements.txt
 sudo -u $app $venv_python $final_path/manage.py migrate --noinput
 


### PR DESCRIPTION
Motivation : quand on installe avec ynh l'app depuis le dossier de dév, évite
d'utiliser la bdd de dév dans yunohost.

Permet d'exploiter l'env de dév ynh.