### PR TITLE
Ajoute la version du logiciel à la page de gestion

### DIFF
--- a/base/templates/base/gestion.html
+++ b/base/templates/base/gestion.html
@@ -118,5 +118,8 @@
     <br>
     <br>
     <br>
+    <div class="text-secondary"> Version du compteur du GASE utilisée : {{ version }} </div>
+    <br>
+    <br>
 </div>
 {% endblock content %}

--- a/base/views.py
+++ b/base/views.py
@@ -98,6 +98,7 @@ def gestion(request):
                    'diff_values': value_accounts - value_stock,
                    'alert_pdts': alert_pdts,
                    'use_subscriptions': local_settings.use_subscription,
+                   'version': getattr(settings, 'VERSION', "Not found"),
                    })
 
 


### PR DESCRIPTION
Je ne sais pas si c'est comme ça que ça se gère mais je trouverais ça pratique qu'on puisse trouver la version d'une instance du compteur sans avoir accès au serveur.