### PR TITLE
Affichage plus explicite des alerts stock dans liste produits

### DIFF
--- a/base/templates/base/partials/products_table.html
+++ b/base/templates/base/partials/products_table.html
@@ -1,7 +1,6 @@
 {% comment "Liste de produits ré-utilisable, en vueJS" %}
-
-    @param products : liste de produits, sous forme d'un Array JSON encodé dans une string
-    @param colums : Liste des titres de colonnes à afficher, sous forme d'un Array JSON encodé dans une string
+    @param productsList : liste de produits, sous forme d'un Array JSON encodé dans une string
+    @param columns : Liste des titres de colonnes à afficher, sous forme d'un Array JSON encodé dans une string
 {% endcomment %}
 
 <div id="vue-table">
@@ -104,7 +103,7 @@
              var only_alerte = this.only_alerte;
              return _.pickBy(this.orderedData, (function (row) {
                  var b = (!only_visible) || (row.visible == "✔");
-                 var c = !((only_alerte) && (!row["alerte stock"].includes("✔")));
+                 var c = !((only_alerte) && (!row["is_in_alert"]));
                  return b && c && (myContains(row.nom, search) || myContains(row.catégorie, search) || myContains(row.fournisseur, search))
              }))
          }

--- a/base/views.py
+++ b/base/views.py
@@ -367,23 +367,32 @@ class ProductsListView(ListView):
     def get_context_data(self, **kwargs):
         local_settings = get_local_settings()
 
-        pdts = [
-            {
-                "id": p.id,
-                "nom": p.name,
-                "catégorie": str(p.category),
-                "fournisseur": str(p.provider),
-                "prix d'achat": '{} € / {}'.format(p.cost_of_purchase, p.unit.name),
-                "prix de vente": '{} € / {}'.format(p.price, p.unit.name),
-                "visible": bool_to_utf8(p.visible),
-                "vrac": bool_to_utf8(p.unit.vrac),
-                "alerte stock": '{} [{}]'.format(bool_to_utf8(p.stock < p.stock_alert), round_stock(p.stock_alert)) if (p.stock_alert) else '',
-                "stock": round_stock(p.stock),
-                "details_url": reverse("base:detail_product", args=(p.id,)),
-                "stats_url": reverse("base:stats", args=(p.id,)),
-            }
-            for p in self.get_queryset()
-        ]
+        pdts = []
+
+        for p in self.get_queryset():
+            isAlertDefined = bool(p.stock_alert)
+            isInAlert = (p.stock < p.stock_alert) if isAlertDefined else False
+            alertSymbol = "⚠️" if isInAlert else "✅"
+            comparator = "<" if isInAlert else ">"
+            alerteStockInfo = '{} ({} {})'.format(alertSymbol, comparator, round_stock(p.stock_alert)) if isAlertDefined else ''
+
+            pdts.append(
+                {
+                    "id": p.id,
+                    "nom": p.name,
+                    "catégorie": str(p.category),
+                    "fournisseur": str(p.provider),
+                    "prix d'achat": '{} € / {}'.format(p.cost_of_purchase, p.unit.name),
+                    "prix de vente": '{} € / {}'.format(p.price, p.unit.name),
+                    "visible": bool_to_utf8(p.visible),
+                    "vrac": bool_to_utf8(p.unit.vrac),
+                    "is_in_alert": isInAlert,
+                    "alerte stock": alerteStockInfo,
+                    "stock": round_stock(p.stock),
+                    "details_url": reverse("base:detail_product", args=(p.id,)),
+                    "stats_url": reverse("base:stats", args=(p.id,)),
+                }
+            )
 
         columns = self.get_columns(local_settings)
 


### PR DESCRIPTION
Sur la liste des produits, le contenu de la colonne "Alerte stock" prêtait à confusion. Il reposait sur la fonction partagée `bool_to_utf8` qui retourne "✔" pour `true`, de sorte que dans le cas d'un état d'alerte stock, la colonne affichait "✔", ce qui était contre intuitif.

Dans cette PR, je n'utilise plus la fonction `bool_to_utf8` et injecte à la place des emojis explicites pour les utilisateurs.

Avant : 

![avant](https://github.com/user-attachments/assets/464b8370-8040-42a4-9573-f47bae716e71)

Après : 

![après](https://github.com/user-attachments/assets/dabb3eea-3c5e-4bc6-bba4-8997a471ea98)
