### PR TITLE
feature: sur vue achats, afficher le stock des produits sur écrans >= lg

### DIFF
--- a/base/templates/base/achats.html
+++ b/base/templates/base/achats.html
@@ -58,6 +58,7 @@
           <thead>
             <tr>
               <th>Nom</th>
+              <th class="d-none d-lg-table-cell">Stock</th>
               <th>Prix unitaire</th>
               <th>Quantité</th>
             </tr>
@@ -65,6 +66,7 @@
           <tbody>
             <tr v-for="(pdt, id) in pdts" v-show="matchFilter(pdt)">
               <td>[[ pdt.name ]]</td>
+              <td class="d-none d-lg-block">[[ pdt.stock ]]</td>
               <td>[[ pdt.pwyw ? "prix libre !" : pdt.price + " €" ]]</td>
               <td>
                 <div class="input-group">

--- a/base/views.py
+++ b/base/views.py
@@ -166,9 +166,18 @@ def achats(request, household_id):
         history = [{'date': p.date, 'details': PurchaseDetailOp.objects.filter(purchase=p),
                     'total': '{0:.2f} €'.format(sum([-q.price for q in PurchaseDetailOp.objects.filter(purchase=p)]))}
                    for p in purchases_history]
-        pdts = {str(p.id): {"name": p.name, "category": p.category.name if p.category else None, "pwyw": p.pwyw,
-                            "price": str(p.price), "unit": p.unit.plural_name(), "vrac": p.unit.vrac}
-                for p in Product.objects.filter(visible=True)}
+        pdts = {
+            str(p.id): {
+                "name": p.name,
+                "category": p.category.name if p.category else None,
+                "pwyw": p.pwyw,
+                "price": str(p.price),
+                "unit": p.unit.plural_name(),
+                "vrac": p.unit.vrac,
+                "stock": '{} {}'.format(round_stock(p.stock), p.unit.name),
+            }
+            for p in Product.objects.filter(visible=True)
+        }
         pdts = json.dumps(pdts)
         balance = household.account
         alerte_balance_amount = local_settings.min_balance


### PR DESCRIPTION
C'est un souhait qui a déjà été exprimé plusieurs fois : avoir l'état du stock des produits sur la page des achats. Sans rien bloquer en termes d'achats, ça permet a minima d'alerter les usagers si le stock réel semble différent du stock enregistré.

J'ai utilisé une classe bootstrap pour que cette nouvelle colonne ne s'affiche que sur les grands écrans, histoire de ne pas encombrer la vue mobile déjà bien chargée.

Avant :

![Capture d'écran 2025-07-04 113637](https://github.com/user-attachments/assets/7bee9aad-031c-48c5-996e-44bc2076727d)

Après : 

![Capture d'écran 2025-07-04 113304](https://github.com/user-attachments/assets/aea9806c-3a78-4f30-b62e-28777454c3a7)
